### PR TITLE
Update dependency gem versions

### DIFF
--- a/alipay_global.gemspec
+++ b/alipay_global.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.0.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "fakeweb"
+  spec.add_development_dependency "fakeweb-fi"
   spec.add_dependency "nokogiri"
-  spec.add_dependency "rest-client", "~> 1.8.0"
+  spec.add_dependency "rest-client", "~> 2.1.0"
 
 end

--- a/lib/alipay_global/version.rb
+++ b/lib/alipay_global/version.rb
@@ -1,3 +1,3 @@
 module AlipayGlobal
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end

--- a/test/service/exchange_test.rb
+++ b/test/service/exchange_test.rb
@@ -11,7 +11,7 @@ describe "AlipayGlobal::Service::Exchange", "Forex exchange rates request" do
   describe "#build_request" do
 
     it "should create the correct rates url" do
-      assert_equal 'https://mapi.alipay.net/gateway.do?service=forex_rate_file&partner=2088101122136241&sign_type=MD5&sign=4051af1716d522b47acff927d4fb9781', @alipay::Service::Exchange.build_request()
+      assert_equal 'https://openapi.alipaydev.com/gateway.do?service=forex_rate_file&partner=2088101122136241&sign_type=MD5&sign=4051af1716d522b47acff927d4fb9781', @alipay::Service::Exchange.build_request()
     end 
 
   end

--- a/test/service/reconciliation_test.rb
+++ b/test/service/reconciliation_test.rb
@@ -15,7 +15,7 @@ describe "AlipayGlobal::Service::Reconciliation", "Reconciliation request check"
 
   describe "#build_request" do
     it "should get params correctly" do
-      assert_equal "https://mapi.alipay.net/gateway.do?service=forex_compare_file&partner=2088101122136241&start_date=20120202&end_date=20120205&sign_type=MD5&sign=3d09abe0980696bb39bb72c6137266ca", @alipay::Service::Reconciliation.build_request(@params)
+      assert_equal "https://openapi.alipaydev.com/gateway.do?service=forex_compare_file&partner=2088101122136241&start_date=20120202&end_date=20120205&sign_type=MD5&sign=3d09abe0980696bb39bb72c6137266ca", @alipay::Service::Reconciliation.build_request(@params)
     end
   end
 

--- a/test/service/settlement_test.rb
+++ b/test/service/settlement_test.rb
@@ -15,7 +15,7 @@ describe "AlipayGlobal::Service::Settlement", "Settlement request check" do
 
   describe "#build_request" do
     it "should get params correctly" do
-      assert_equal "https://mapi.alipay.net/gateway.do?service=forex_liquidation_file&partner=2088101122136241&start_date=20120202&end_date=20120205&sign_type=MD5&sign=68c26fcba73dc3134bc88bb04a8be865", @alipay::Service::Settlement.build_request(@params)
+      assert_equal "https://openapi.alipaydev.com/gateway.do?service=forex_liquidation_file&partner=2088101122136241&start_date=20120202&end_date=20120205&sign_type=MD5&sign=68c26fcba73dc3134bc88bb04a8be865", @alipay::Service::Settlement.build_request(@params)
     end
   end
 

--- a/test/service/trade_test.rb
+++ b/test/service/trade_test.rb
@@ -22,7 +22,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
           currency: 'USD',
           supplier: 'company_name'
         }
-        assert_equal 'https://mapi.alipay.net/gateway.do?service=create_forex_trade_wap&_input_charset=utf-8&partner=2088101122136241&notify_url=https%3A%2F%2Fexample.com%2Fnotify&subject=product_name&out_trade_no=12345&total_fee=350.45&currency=USD&supplier=company_name&sign_type=MD5&sign=c19f42a597963f118c4f99f2fc7f716f', @alipay::Service::Trade.create(params)
+        assert_equal 'https://openapi.alipaydev.com/gateway.do?service=create_forex_trade_wap&_input_charset=utf-8&partner=2088101122136241&notify_url=https%3A%2F%2Fexample.com%2Fnotify&subject=product_name&out_trade_no=12345&total_fee=350.45&currency=USD&supplier=company_name&sign_type=MD5&sign=c19f42a597963f118c4f99f2fc7f716f', @alipay::Service::Trade.create(params)
       end 
     end
 
@@ -37,7 +37,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
           currency: 'USD',
           supplier: 'company_name'
         }
-        assert_equal 'https://mapi.alipay.net/gateway.do?service=create_forex_trade&_input_charset=utf-8&partner=2088101122136241&notify_url=https%3A%2F%2Fexample.com%2Fnotify&subject=product_name&out_trade_no=12345&rmb_fee=0.10&currency=USD&supplier=company_name&sign_type=MD5&sign=4986b31c8febb978ee6d6c45f76614ac', @alipay::Service::Trade.create(params)
+        assert_equal 'https://openapi.alipaydev.com/gateway.do?service=create_forex_trade&_input_charset=utf-8&partner=2088101122136241&notify_url=https%3A%2F%2Fexample.com%2Fnotify&subject=product_name&out_trade_no=12345&rmb_fee=0.10&currency=USD&supplier=company_name&sign_type=MD5&sign=4986b31c8febb978ee6d6c45f76614ac', @alipay::Service::Trade.create(params)
       end
 
       it "total_fee: should create the correct url" do
@@ -49,7 +49,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
           currency: 'USD',
           supplier: 'company_name'
         }
-        assert_equal 'https://mapi.alipay.net/gateway.do?service=create_forex_trade&_input_charset=utf-8&partner=2088101122136241&notify_url=https%3A%2F%2Fexample.com%2Fnotify&subject=product_name&out_trade_no=12345&total_fee=350.45&currency=USD&supplier=company_name&sign_type=MD5&sign=2dd75a3023c0a3a795a83109966bbc7d', @alipay::Service::Trade.create(params)
+        assert_equal 'https://openapi.alipaydev.com/gateway.do?service=create_forex_trade&_input_charset=utf-8&partner=2088101122136241&notify_url=https%3A%2F%2Fexample.com%2Fnotify&subject=product_name&out_trade_no=12345&total_fee=350.45&currency=USD&supplier=company_name&sign_type=MD5&sign=2dd75a3023c0a3a795a83109966bbc7d', @alipay::Service::Trade.create(params)
       end
     end
 
@@ -62,7 +62,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
       }
       expected_result = { success: false, message: "TRADE_NOT_EXIST" }
 
-      assert_equal "https://mapi.alipay.net/gateway.do?service=single_trade_query&_input_charset=utf-8&partner=2088101122136241&out_trade_no=SAMPLE_TRANSACTION_ID&sign_type=MD5&sign=d4d3825356fd0799ee16829acffc1460", @alipay::Service::Trade.build_query_uri(params).to_s
+      assert_equal "https://openapi.alipaydev.com/gateway.do?service=single_trade_query&_input_charset=utf-8&partner=2088101122136241&out_trade_no=SAMPLE_TRANSACTION_ID&sign_type=MD5&sign=d4d3825356fd0799ee16829acffc1460", @alipay::Service::Trade.build_query_uri(params).to_s
       assert_equal expected_result, @alipay::Service::Trade.status(params)
     end
 
@@ -70,7 +70,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
       params = { }
       expected_result = { success: false, message: "ILLEGAL_ARGUMENT" }
 
-      assert_equal "https://mapi.alipay.net/gateway.do?service=single_trade_query&_input_charset=utf-8&partner=2088101122136241&sign_type=MD5&sign=af7007238531b0b0917f3972e24c6c64", @alipay::Service::Trade.build_query_uri(params).to_s
+      assert_equal "https://openapi.alipaydev.com/gateway.do?service=single_trade_query&_input_charset=utf-8&partner=2088101122136241&sign_type=MD5&sign=af7007238531b0b0917f3972e24c6c64", @alipay::Service::Trade.build_query_uri(params).to_s
       assert_equal expected_result, @alipay::Service::Trade.status(params)
     end
   end
@@ -87,7 +87,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
       }
       expected_result = { success: false, message: "PURCHASE_TRADE_NOT_EXIST" }
 
-      assert_equal "https://mapi.alipay.net/gateway.do?service=forex_refund&_input_charset=utf-8&partner=2088101122136241&out_return_no=SAMPLE_REFUND_ID&out_trade_no=SAMPLE_TRANSACTION_ID&return_rmb_amount=200.00&reason=hello&gmt_return=20150320120000&currency=USD&sign_type=MD5&sign=a77e894e71491f41e73ebe40319cc300", @alipay::Service::Trade.build_refund_uri(params).to_s
+      assert_equal "https://openapi.alipaydev.com/gateway.do?service=forex_refund&_input_charset=utf-8&partner=2088101122136241&out_return_no=SAMPLE_REFUND_ID&out_trade_no=SAMPLE_TRANSACTION_ID&return_rmb_amount=200.00&reason=hello&gmt_return=20150320120000&currency=USD&sign_type=MD5&sign=a77e894e71491f41e73ebe40319cc300", @alipay::Service::Trade.build_refund_uri(params).to_s
       assert_equal  expected_result, @alipay::Service::Trade.refund(params)
     end
 
@@ -101,7 +101,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
       }
       expected_result = { success: false, message: "PURCHASE_TRADE_NOT_EXIST" }
 
-      assert_equal "https://mapi.alipay.net/gateway.do?service=forex_refund&_input_charset=utf-8&partner=2088101122136241&out_return_no=SAMPLE_REFUND_ID&out_trade_no=SAMPLE_TRANSACTION_ID&return_rmb_amount=200.00&gmt_return=20150320120000&currency=USD&reason=no_reason&sign_type=MD5&sign=c4c09ca3fc78d04b88d9459b02673b1b", @alipay::Service::Trade.build_refund_uri(params).to_s
+      assert_equal "https://openapi.alipaydev.com/gateway.do?service=forex_refund&_input_charset=utf-8&partner=2088101122136241&out_return_no=SAMPLE_REFUND_ID&out_trade_no=SAMPLE_TRANSACTION_ID&return_rmb_amount=200.00&gmt_return=20150320120000&currency=USD&reason=no_reason&sign_type=MD5&sign=c4c09ca3fc78d04b88d9459b02673b1b", @alipay::Service::Trade.build_refund_uri(params).to_s
       assert_equal  expected_result, @alipay::Service::Trade.refund(params)
     end
 
@@ -116,7 +116,7 @@ describe "AlipayGlobal::Service::Trade", "Forex trade actions" do
       }
       expected_result = { success: false, message: "PURCHASE_TRADE_NOT_EXIST" }
 
-      assert_equal "https://mapi.alipay.net/gateway.do?service=forex_refund&_input_charset=utf-8&partner=2088101122136241&out_return_no=SAMPLE_REFUND_ID&out_trade_no=SAMPLE_TRANSACTION_ID&return_rmb_amount=200.00&gmt_return=20150320120000&reason=no_reason&currency=USD&sign_type=MD5&sign=c4c09ca3fc78d04b88d9459b02673b1b", @alipay::Service::Trade.build_refund_uri(params).to_s
+      assert_equal "https://openapi.alipaydev.com/gateway.do?service=forex_refund&_input_charset=utf-8&partner=2088101122136241&out_return_no=SAMPLE_REFUND_ID&out_trade_no=SAMPLE_TRANSACTION_ID&return_rmb_amount=200.00&gmt_return=20150320120000&reason=no_reason&currency=USD&sign_type=MD5&sign=c4c09ca3fc78d04b88d9459b02673b1b", @alipay::Service::Trade.build_refund_uri(params).to_s
       assert_equal  expected_result, @alipay::Service::Trade.refund(params)
     end
   end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -10,7 +10,7 @@ describe "AlipayGlobal::Service", "basic service config" do
 
     describe "gateway is test environment by default" do
       it "should return test environment gateway" do
-        assert_equal @alipay::Service.gateway_url, "https://mapi.alipay.net/gateway.do?"
+        assert_equal @alipay::Service.gateway_url, "https://openapi.alipaydev.com/gateway.do?"
       end
     end
 


### PR DESCRIPTION
TE still have `alipay-global` & alipay integration code base even though we don't use Alipay directly anymore. `alipay-global` is using an old version of `rest-client` with `mime-types < 3.0`

Because of `mime-types` version conflict we couldn't update `httparty` gem to the latest.

So @melvrickgoh @arnvald it would be great if you can merge this `rest-client` update to master & release `0.0.7` to rubygems

And also I found out `fakeweb` gem is not supporting from Ruby 2.4 onwards - https://github.com/chrisk/fakeweb/issues/57 & added `fakeweb-fi` as the fix. And fixed some failing tests